### PR TITLE
Fix issue #4.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,8 @@ Changelog
 Unreleased_
 -----------
 
+* Fixed issue #4 which caused typing errors in code using
+  :code:`DataclassBuilder`.
 
 
 v0.0.2 - 2019-03-12

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ coverage: check
 
 check:
 	@mypy $(module)
+	@mypy --config-file tests/mypy.ini tests
 	@flake8 $(module) tests
 	@python -m pylint $(module)
 	@python -m pycodestyle $(module) tests

--- a/dataclass_builder/__init__.py
+++ b/dataclass_builder/__init__.py
@@ -87,7 +87,7 @@ Accessing a field of the builder before it is set results in an
 
 import dataclasses
 import itertools
-from typing import Any, Mapping
+from typing import Any, Mapping, TYPE_CHECKING
 
 __version__ = '0.0.2a1'
 
@@ -239,6 +239,11 @@ class DataclassBuilder:
             raise UndefinedFieldError(
                 f"dataclass '{self.__dataclass.__name__}' does not define "
                 f"field '{item}'", self.__dataclass, item)
+
+    if TYPE_CHECKING:
+        # tells type checking that it should ignore attribute access
+        def __getattr__(self, item: str) -> Any:
+            return self.__getattribute__(item)
 
     def __repr__(self) -> str:
         """Print a representation of the builder.

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,3 +8,6 @@ universal=1
 ignore=D105, D107, D203, D212, D213, D402, D413
 ignore-decorators=property
 
+[coverage:report]
+exclude_lines =
+    if TYPE_CHECKING:

--- a/tests/mypy.ini
+++ b/tests/mypy.ini
@@ -1,0 +1,5 @@
+[mypy]
+warn_unused_configs = True
+check_untyped_defs = True
+warn_redundant_casts = True
+warn_unused_ignores = True

--- a/tests/test_dataclassbuilder.py
+++ b/tests/test_dataclassbuilder.py
@@ -1,10 +1,11 @@
-import pytest
+import pytest  # type: ignore
 
 import dataclasses
 from dataclass_builder import (DataclassBuilder, MissingFieldError,
                                UndefinedFieldError, build)
-from tests.conftest import (PixelCoord, Point, Circle, NotADataclass,
-                            NoFields, NoInitFields, ExtendedBuilder)
+from tests.conftest import (PixelCoord, Point, Circle,  # type: ignore
+                            NotADataclass, NoFields, NoInitFields,
+                            ExtendedBuilder)
 
 
 def test_all_fields_set():

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,5 +1,6 @@
 from dataclass_builder import DataclassBuilder, fields
-from tests.conftest import PixelCoord, Point, Circle, Types, ExtendedBuilder
+from tests.conftest import (PixelCoord, Point, Circle, Types,  # type: ignore
+                            ExtendedBuilder)
 
 
 def test_returns_settable_fields():


### PR DESCRIPTION
This fixes issue #4 by adding the `getattr` method when type checking.  This
tricks type checkers such as Mypy into allowing arbitrary attribute access.