### PR TITLE
Fix issue #9.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,9 @@ Changelog
 Unreleased_
 -----------
 
+* Fix issue #9 relating to the :code:`dataclass_builder` factory function
+  failing to handle dataclasses which use types from the :code:`typing` module.
+
 
 v1.1.1_ - 2019-03-27
 --------------------

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import math
+from typing import Sequence, Mapping
 from dataclasses import dataclass, field
 from dataclass_builder import DataclassBuilder
 
@@ -60,3 +61,9 @@ class Build:
 @dataclass
 class Fields:
     fields: str
+
+
+@dataclass
+class Typing:
+    sequence: Sequence[int]
+    mapping: Mapping[str, float]

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -9,7 +9,7 @@ from dataclass_builder import (MissingFieldError, UndefinedFieldError,
 from dataclass_builder.factory import _create_fn
 from tests.conftest import (Circle, PixelCoord, Point,  # type: ignore
                             NoFields, NoInitFields, NotADataclass,
-                            Build, Fields, Types)
+                            Build, Fields, Types, Typing)
 
 
 def test_create_fn():
@@ -424,3 +424,10 @@ def test_init_annotations():
     annotations = get_type_hints(builder.__init__)
     assert annotations == {
         'int_': int, 'float_': float, 'str_': str, 'return': type(None)}
+
+
+def test_typing_module():
+    TypingBuilder = dataclass_builder(Typing)
+    builder = TypingBuilder()
+    builder.sequence = [1, 2, 3]
+    builder.mapping = {'one': 1.0, 'two': 2.0, 'pi': 3.14}

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -6,7 +6,7 @@ from dataclass_builder import (DataclassBuilder, MissingFieldError,
                                build, fields)
 from tests.conftest import (PixelCoord, Point, Circle,  # type: ignore
                             NotADataclass, NoFields, NoInitFields,
-                            ExtendedBuilder, Types)
+                            ExtendedBuilder, Types, Typing)
 
 
 def test_all_fields_set():
@@ -265,3 +265,9 @@ def test_class_inheritance():
     assert ['int_', 'float_', 'str_'] == list(fields_.keys())
     assert ['int_', 'float_', 'str_'] == [f.name for f in fields_.values()]
     assert [int, float, str] == [f.type for f in fields_.values()]
+
+
+def test_typing_module():
+    builder = DataclassBuilder(Typing)
+    builder.sequence = [1, 2, 3]
+    builder.mapping = {'one': 1.0, 'two': 2.0, 'pi': 3.14}


### PR DESCRIPTION
Falls back on `repr` to get the name of the type if `__qualname__` is not an
attribute.