### PR TITLE
Replace equality with identity where possible.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,9 @@ Unreleased_
 
 * Fix issue #9 relating to the :code:`dataclass_builder` factory function
   failing to handle dataclasses which use types from the :code:`typing` module.
+* Replace equality checks with identity checks where possible.  This was not
+  only the intention of the checks but by using identity, compatibility with
+  types that have broken equality operators is restored.
 
 
 v1.1.1_ - 2019-03-27

--- a/dataclass_builder/_common.py
+++ b/dataclass_builder/_common.py
@@ -80,8 +80,8 @@ def _is_required(field: 'dataclasses.Field[Any]') -> bool:
         True if the :paramref:`field` is required, otherwise False.
 
     """
-    return (field.init and field.default == dataclasses.MISSING and
-            field.default_factory == dataclasses.MISSING)  # type: ignore
+    return (field.init and field.default is dataclasses.MISSING and
+            field.default_factory is dataclasses.MISSING)  # type: ignore
 
 
 def _is_optional(field: 'dataclasses.Field[Any]') -> bool:
@@ -99,8 +99,8 @@ def _is_optional(field: 'dataclasses.Field[Any]') -> bool:
 
     """
     return (field.init and
-            (field.default != dataclasses.MISSING or
-             field.default_factory != dataclasses.MISSING))  # type: ignore
+            (field.default is not dataclasses.MISSING) or
+            (field.default_factory is not dataclasses.MISSING))  # type: ignore
 
 
 def _settable_fields(dataclass: Any) -> Mapping[str, 'dataclasses.Field[Any]']:

--- a/dataclass_builder/factory.py
+++ b/dataclass_builder/factory.py
@@ -364,14 +364,14 @@ def dataclass_builder(dataclass: Any, *, name: Optional[str] = None) -> type:
         """
         # check for missing required fields
         for name, field in required_fields.items():
-            if getattr(self, name) == REQUIRED:
+            if getattr(self, name) is REQUIRED:
                 raise MissingFieldError(
                     f"field '{name}' of dataclass '{dataclass.__qualname__}' "
                     "is not optional", dataclass, field)
         # build dataclass
         kwargs = {name: getattr(self, name)
                   for name in settable_fields
-                  if getattr(self, name) != OPTIONAL}
+                  if getattr(self, name) is not OPTIONAL}
         return dataclass(**kwargs)
 
     def _fields_method(

--- a/dataclass_builder/wrapper.py
+++ b/dataclass_builder/wrapper.py
@@ -279,7 +279,7 @@ class DataclassBuilder:
         """
         # check for missing required fields
         for name, field in _required_fields(self.__dataclass).items():
-            if getattr(self, name) == REQUIRED:
+            if getattr(self, name) is REQUIRED:
                 raise MissingFieldError(
                     f"field '{name}' of dataclass "
                     f"'{self.__dataclass.__qualname__}' "
@@ -287,7 +287,7 @@ class DataclassBuilder:
         # build dataclass
         kwargs = {name: getattr(self, name)
                   for name in self.__settable_fields
-                  if getattr(self, name) != OPTIONAL}
+                  if getattr(self, name) is not OPTIONAL}
         return self.__dataclass(**kwargs)
 
     def _fields(self, required: bool = True, optional: bool = True) -> \

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -8,10 +8,10 @@ from tests.conftest import PixelCoord, Point, Circle, Types  # type: ignore
 
 
 def test_constants():
-    assert REQUIRED == REQUIRED
-    assert REQUIRED != OPTIONAL
-    assert OPTIONAL == OPTIONAL
-    assert OPTIONAL != REQUIRED
+    assert REQUIRED is REQUIRED
+    assert REQUIRED is not OPTIONAL
+    assert OPTIONAL is OPTIONAL
+    assert OPTIONAL is not REQUIRED
     assert repr(REQUIRED) == 'REQUIRED'
     assert repr(OPTIONAL) == 'OPTIONAL'
 


### PR DESCRIPTION
This replaces uses of `==` with `is` and uses of `!=` with `is not` where possible.  In all of the cases this was happening anyways since Python was falling back on identity.  However, this caused problems when using field values of types that implemented `__eq__` incorrectly.  By using the proper check (identity) from the start these problems can be avoided.